### PR TITLE
fix(ci): Partial revert of #154

### DIFF
--- a/.github/workflows/delete-images.yml
+++ b/.github/workflows/delete-images.yml
@@ -16,7 +16,7 @@ jobs:
           PER_PAGE: 100
 
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN}}
+          github-token: ${{ secrets.DELETE_PACKAGES_TOKEN }}
           script: |
             const response = await github.request("GET /orgs/${{ github.repository_owner }}/packages/container/${{ env.PACKAGE_NAME }}/versions",
               { per_page: ${{ env.PER_PAGE }}


### PR DESCRIPTION
Partial revert of #154 for .github/workflows/delete-images.yml

* GITHUB_TOKEN is not yet working for deleting containers