### PR TITLE
Make server port configurable

### DIFF
--- a/Configuration/Configuration.cpp
+++ b/Configuration/Configuration.cpp
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  *
  * Copyright 2021 (c) Christian von Arnim, ISW University of Stuttgart (for umati and VDW e.V.)
+ * Copyright 2022 (c) Alen Galinec
  */
 
 #include "Configuration.hpp"
@@ -11,6 +12,7 @@ namespace Configuration {
 Configuration DefaultConfiguration() {
   Configuration ret;
   ret.Hostname = "localhost";
+  ret.Port = 4840;
   Encryption_t enc;
   enc.ServerKey = "Server_key.pem";
   enc.ServerCert = "Server_cert.pem";

--- a/Configuration/Configuration.hpp
+++ b/Configuration/Configuration.hpp
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  *
  * Copyright 2021 (c) Christian von Arnim, ISW University of Stuttgart (for umati and VDW e.V.)
+ * Copyright 2022 (c) Alen Galinec
  */
 
 #include <optional>
@@ -30,6 +31,7 @@ struct UserPassAuthentication_t {
 
 struct Configuration {
   std::optional<std::string> Hostname;
+  std::optional<std::uint16_t> Port;
   std::optional<std::vector<UserPassAuthentication_t>> UserPassAuthentication;
   std::optional<Encryption_t> Encryption;
 };

--- a/Configuration/Configuration_json.cpp
+++ b/Configuration/Configuration_json.cpp
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  *
  * Copyright 2021 (c) Christian von Arnim, ISW University of Stuttgart (for umati and VDW e.V.)
+ * Copyright 2022 (c) Alen Galinec
  */
 
 #include "Configuration_json.hpp"
@@ -20,6 +21,10 @@ void from_json(const nlohmann::json &j, Configuration &p) {
   // check
   if (j.count("Hostname") != 0) {
     p.Hostname = j.at("Hostname").get<decltype(p.Hostname)::value_type>();
+  }
+
+  if (j.count("Port") != 0) {
+    p.Port = j.at("Port").get<decltype(p.Port)::value_type>();
   }
 
   if (j.count("Encryption") != 0) {

--- a/SampleServer.cpp
+++ b/SampleServer.cpp
@@ -5,6 +5,7 @@
  * Copyright 2021 (c) Götz Görisch, VDW - Verein Deutscher Werkzeugmaschinenfabriken e.V.
  * Copyright 2021 (c) Christoph Ruckstetter, Michael Weinig AG
  * Copyright 2022 (c) Sebastian Friedl, ISW University of Stuttgart (for VDMA e.V.)
+ * Copyright 2022 (c) Alen Galinec
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -121,15 +122,14 @@ UA_StatusCode setServerConfig(UA_ServerConfig *pConfig, const Configuration::Con
   UA_CertificateVerification_AcceptAll(&pConfig->certificateVerification);
   // Use Default sizes
   std::vector<std::string> serverUrls;
-  constexpr int port = 4840;
   {
     std::stringstream ss;
-    ss << "opc.tcp://:" << port;
+    ss << "opc.tcp://:" << *configFile.Port;
     serverUrls.push_back(ss.str());
   }
   if (configFile.Hostname.has_value()) {
     std::stringstream ss;
-    ss << "opc.tcp://" << *configFile.Hostname << ":" << port;
+    ss << "opc.tcp://" << *configFile.Hostname << ":" << *configFile.Port;
     serverUrls.push_back(ss.str());
   }
   pConfig->serverUrls = (UA_String *)UA_Array_new(serverUrls.size(), &UA_TYPES[UA_TYPES_STRING]);

--- a/configuration.template.json
+++ b/configuration.template.json
@@ -1,10 +1,13 @@
 {
     "Hostname": "localhost",
+    "Port": 4840,
     "UserPassAuthentication": [],
     "Encryption": {
         "ServerCert": "server_cert.der",
         "ServerKey": "server_key.der",
-        "TrustedClients": ["trusted/trustedClient.der"],
+        "TrustedClients": [
+            "trusted/trustedClient.der"
+        ],
         "IssuerCerts": [],
         "Revocation": []
     }


### PR DESCRIPTION
Add the option to configure the port to which the server should bind. This is helpful for machines where the default port 4840 is taken or otherwise restricted.