### PR TITLE
refactor: Correct naming for SignalModeLight

### DIFF
--- a/MachineTools/InstantiatedMachineTool.cpp
+++ b/MachineTools/InstantiatedMachineTool.cpp
@@ -58,7 +58,7 @@ void InstantiatedMachineTool::InstantiateIdentification() {
 void InstantiatedMachineTool::InstantiateMonitoringStacklight(std::list<UA_SignalColor> stacklightColors) {
   InstantiateOptional(mt.Monitoring->Stacklight, m_pServer, n);
   InstantiateOptional(mt.Monitoring->Stacklight->NodeVersion, m_pServer, n);
-  mt.Monitoring->Stacklight->StacklightMode = UA_StacklightOperationMode::UA_STACKLIGHTOPERATIONMODE_SEGMENTED;
+  mt.Monitoring->Stacklight->SignalMode = UA_StacklightOperationMode::UA_STACKLIGHTOPERATIONMODE_SEGMENTED;
 
   // Store size, as the list will become shorter
   std::size_t s = stacklightColors.size();
@@ -68,9 +68,9 @@ void InstantiatedMachineTool::InstantiateMonitoringStacklight(std::list<UA_Signa
     auto &light = mt.Monitoring->Stacklight->OrderedObjects.Add(m_pServer, n, {m_nsIndex, ss.str()});
     InstantiateOptional(light.IsPartOfBase, m_pServer, n);
     InstantiateOptional(light.SignalOn, m_pServer, n);
-    InstantiateOptional(light.StacklightMode, m_pServer, n);
+    InstantiateOptional(light.SignalMode, m_pServer, n);
 
-    light.StacklightMode = UA_SignalModeLight::UA_SIGNALMODELIGHT_CONTINUOUS;
+    light.SignalMode = UA_SignalModeLight::UA_SIGNALMODELIGHT_CONTINUOUS;
     light.IsPartOfBase = false;
     light.NumberInList = i;
     light.SignalOn = true;

--- a/TypeDefinition/IA/BasicStacklight.hpp
+++ b/TypeDefinition/IA/BasicStacklight.hpp
@@ -15,7 +15,7 @@
 namespace ia {
 
 struct BasicStacklight_t : public ns0::OrderedList_t<StackElementLight_t> {
-  BindableMemberValue<UA_StacklightOperationMode> StacklightMode;
+  BindableMemberValue<UA_StacklightOperationMode> SignalMode;
 };
 
 }  // namespace ia
@@ -24,5 +24,5 @@ REFL_TYPE(
   ia::BasicStacklight_t,
   Bases<ns0::OrderedList_t<ia::StackElementLight_t>>(),
   UmatiServerLib::attribute::UaObjectType(UmatiServerLib::constexp::NodeId(constants::NsIAUri, UA_IAID_BASICSTACKLIGHTTYPE)))
-REFL_FIELD(StacklightMode)
+REFL_FIELD(SignalMode)
 REFL_END

--- a/TypeDefinition/IA/StackElementLight.hpp
+++ b/TypeDefinition/IA/StackElementLight.hpp
@@ -18,7 +18,7 @@ namespace ia {
 struct StackElementLight_t : public StackElement_t {
   BindableMember<ns0::AnalogItem_t<float>> Intensity;
   BindableMemberValue<UA_SignalColor> SignalColor;
-  BindableMemberValue<UA_SignalModeLight> StacklightMode;
+  BindableMemberValue<UA_SignalModeLight> SignalMode;
 };
 
 }  // namespace ia
@@ -36,7 +36,7 @@ REFL_FIELD(
   UmatiServerLib::attribute::MemberInTypeNodeId(UmatiServerLib::constexp::NodeId(constants::NsIAUri, UA_IAID_STACKELEMENTLIGHTTYPE_SIGNALCOLOR)),
   UmatiServerLib::attribute::PlaceholderOptional())
 REFL_FIELD(
-  StacklightMode,
+  SignalMode,
   UmatiServerLib::attribute::MemberInTypeNodeId(UmatiServerLib::constexp::NodeId(constants::NsIAUri, UA_IAID_STACKELEMENTLIGHTTYPE_SIGNALMODE)),
   UmatiServerLib::attribute::PlaceholderOptional())
 REFL_END


### PR DESCRIPTION
* previous change: 053223b6a61bcd0ba516255c07c93f0696ef1eb9