### PR TITLE
Partial Revert "refactor: Correct naming for SignalModeLight (#824)"

### DIFF
--- a/MachineTools/InstantiatedMachineTool.cpp
+++ b/MachineTools/InstantiatedMachineTool.cpp
@@ -58,7 +58,7 @@ void InstantiatedMachineTool::InstantiateIdentification() {
 void InstantiatedMachineTool::InstantiateMonitoringStacklight(std::list<UA_SignalColor> stacklightColors) {
   InstantiateOptional(mt.Monitoring->Stacklight, m_pServer, n);
   InstantiateOptional(mt.Monitoring->Stacklight->NodeVersion, m_pServer, n);
-  mt.Monitoring->Stacklight->SignalMode = UA_StacklightOperationMode::UA_STACKLIGHTOPERATIONMODE_SEGMENTED;
+  mt.Monitoring->Stacklight->StacklightMode = UA_StacklightOperationMode::UA_STACKLIGHTOPERATIONMODE_SEGMENTED;
 
   // Store size, as the list will become shorter
   std::size_t s = stacklightColors.size();

--- a/TypeDefinition/IA/BasicStacklight.hpp
+++ b/TypeDefinition/IA/BasicStacklight.hpp
@@ -15,7 +15,7 @@
 namespace ia {
 
 struct BasicStacklight_t : public ns0::OrderedList_t<StackElementLight_t> {
-  BindableMemberValue<UA_StacklightOperationMode> SignalMode;
+  BindableMemberValue<UA_StacklightOperationMode> StacklightMode;
 };
 
 }  // namespace ia
@@ -24,5 +24,5 @@ REFL_TYPE(
   ia::BasicStacklight_t,
   Bases<ns0::OrderedList_t<ia::StackElementLight_t>>(),
   UmatiServerLib::attribute::UaObjectType(UmatiServerLib::constexp::NodeId(constants::NsIAUri, UA_IAID_BASICSTACKLIGHTTYPE)))
-REFL_FIELD(SignalMode)
+REFL_FIELD(StacklightMode)
 REFL_END


### PR DESCRIPTION
This partially reverts commit e02319b44f3a42b24d55f56da10e0847f08a7135.