### PR TITLE
fix: Match order of importing namespaces with CMakeLists

### DIFF
--- a/SampleServer.cpp
+++ b/SampleServer.cpp
@@ -220,10 +220,10 @@ int main(int argc, char *argv[]) {
     std::cout << "No encryption will be available." << std::endl;
   }
 
-  // Create namespaces
+  // Create namespaces, order must match the NAMESPACE_MAP in CMakeLists.txt
   namespace_di_generated(pServer);
-  namespace_ia_generated(pServer);
   namespace_machinery_generated(pServer);
+  namespace_ia_generated(pServer);
   namespace_machinetool_generated(pServer);
   UA_Server_addNamespace(pServer, "Need for namespace index");
   /*namespace_robotics_generated(pServer);*/

--- a/UmatiServerLib/StateMachine.cpp
+++ b/UmatiServerLib/StateMachine.cpp
@@ -90,7 +90,6 @@ StateMachine::State_t StateMachine::readStateValues(open62541Cpp::UA_NodeId stat
   ret.DispName.text = std::string(dispName.text.data, dispName.text.data + dispName.text.length);
   ret.Id = stateObj;
   UA_LocalizedText_clear(&dispName);
-  std::cout << "State: " << ret.DispName.text << std::endl;
   return ret;
 }
 

--- a/initialbuild.sh
+++ b/initialbuild.sh
@@ -23,8 +23,8 @@
 
 BASEDIR=$(pwd)
 
-mkdir build
-cd build || exit
+mkdir build-auto
+cd build-auto || exit
 cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX:PATH="$BASEDIR/install" ../.github/ 
 cmake --build .
 cd SampleServer-build || exit


### PR DESCRIPTION
Fixes #1051 

At the moment, IA and Machinery do not match the order defined in CMakeLists.
https://github.com/umati/Sample-Server/blob/657979f8df6b0b7f626cd6606bdac68cfefa49c5/CMakeLists.txt#L79
https://github.com/umati/Sample-Server/blob/657979f8df6b0b7f626cd6606bdac68cfefa49c5/CMakeLists.txt#L102

![grafik](https://github.com/umati/Sample-Server/assets/3939648/d50afb04-5365-44f3-84dd-32e5c74a2b60)


- Match order of namespacec in Code and CMakeLists definition
- Changed the path in initialbuild.sh so there is no clash with the default paths in VS Code
- Removed debug output of detected state names