### PR TITLE
fix: remove fake namespace

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,35 +137,35 @@ target_sources(
 )
 target_link_libraries(ua_gen_machinetool PUBLIC ua_gen_ia ua_gen_machinery)
 
-ua_generate_nodeset_and_datatypes(
-    NAME "robotics"
-    FILE_NS "${UA_NODESET_DIR}/Robotics/Opc.Ua.Robotics.NodeSet2.xml"
-    FILE_CSV "${UA_NODESET_DIR}/Robotics/NodeIds.csv"
-    FILE_BSD "${UA_NODESET_DIR}/Robotics/Opc.Ua.Robotics.Types.bsd"
-    NAMESPACE_MAP "6:http://opcfoundation.org/UA/Robotics/"
-    TARGET_PREFIX "${PROJECT_NAME}"
-    OUTPUT_DIR "${SAMPLESERVER_GENERATED_NODESET_AND_DATATYPES_OUTPUT_DIR}"
-    DEPENDS di
-)
-
-add_library(ua_gen_robotics)
-target_sources(
-    ua_gen_robotics
-    PRIVATE # cmake-format: sort
-            "${SAMPLESERVER_GENERATED_NODESET_AND_DATATYPES_OUTPUT_DIR}/robotics_nodeids.h"
-            ${UA_NODESET_ROBOTICS_HEADERS}
-            ${UA_NODESET_ROBOTICS_SOURCES}
-            ${UA_TYPES_ROBOTICS_HEADERS}
-            ${UA_TYPES_ROBOTICS_SOURCES}
-)
-target_link_libraries(ua_gen_robotics PUBLIC ua_gen_di)
+#ua_generate_nodeset_and_datatypes(
+#    NAME "robotics"
+#    FILE_NS "${UA_NODESET_DIR}/Robotics/Opc.Ua.Robotics.NodeSet2.xml"
+#    FILE_CSV "${UA_NODESET_DIR}/Robotics/NodeIds.csv"
+#    FILE_BSD "${UA_NODESET_DIR}/Robotics/Opc.Ua.Robotics.Types.bsd"
+#    NAMESPACE_MAP "6:http://opcfoundation.org/UA/Robotics/"
+#    TARGET_PREFIX "${PROJECT_NAME}"
+#    OUTPUT_DIR "${SAMPLESERVER_GENERATED_NODESET_AND_DATATYPES_OUTPUT_DIR}"
+#    DEPENDS di
+#)
+#
+#add_library(ua_gen_robotics)
+#target_sources(
+#    ua_gen_robotics
+#    PRIVATE # cmake-format: sort
+#            "${SAMPLESERVER_GENERATED_NODESET_AND_DATATYPES_OUTPUT_DIR}/robotics_nodeids.h"
+#            ${UA_NODESET_ROBOTICS_HEADERS}
+#            ${UA_NODESET_ROBOTICS_SOURCES}
+#            ${UA_TYPES_ROBOTICS_HEADERS}
+#            ${UA_TYPES_ROBOTICS_SOURCES}
+#)
+#target_link_libraries(ua_gen_robotics PUBLIC ua_gen_di)
 
 ua_generate_nodeset_and_datatypes(
     NAME "woodworking"
     FILE_NS "${PROJECT_SOURCE_DIR}/model/Woodworking/Opc.Ua.Woodworking.NodeSet2.xml"
     FILE_CSV "${PROJECT_SOURCE_DIR}/model/Woodworking/Opc.Ua.Woodworking.NodeIds.csv"
     FILE_BSD "${PROJECT_SOURCE_DIR}/model/Woodworking/Opc.Ua.Woodworking.NodeSet2.bsd"
-    NAMESPACE_MAP "7:http://opcfoundation.org/UA/Woodworking/"
+    NAMESPACE_MAP "6:http://opcfoundation.org/UA/Woodworking/"
     TARGET_PREFIX "${PROJECT_NAME}"
     OUTPUT_DIR "${SAMPLESERVER_GENERATED_NODESET_AND_DATATYPES_OUTPUT_DIR}"
     DEPENDS machinery
@@ -188,7 +188,7 @@ ua_generate_nodeset_and_datatypes(
     FILE_NS "${PROJECT_SOURCE_DIR}/model/GMS/Opc.Ua.MachineryResult.NodeSet2.xml"
     FILE_CSV "${PROJECT_SOURCE_DIR}/model/GMS/Opc.Ua.MachineryResult.NodeSet2.csv"
     FILE_BSD "${PROJECT_SOURCE_DIR}/model/GMS/Opc.Ua.MachineryResult.NodeSet2.bsd"
-    NAMESPACE_MAP "8:http://opcfoundation.org/UA/Machinery/Result/"
+    NAMESPACE_MAP "7:http://opcfoundation.org/UA/Machinery/Result/"
     TARGET_PREFIX "${PROJECT_NAME}"
     OUTPUT_DIR "${SAMPLESERVER_GENERATED_NODESET_AND_DATATYPES_OUTPUT_DIR}"
 )
@@ -210,7 +210,7 @@ ua_generate_nodeset_and_datatypes(
     FILE_NS "${PROJECT_SOURCE_DIR}/model/GMS/opc.ua.gms.nodeset2.xml"
     FILE_CSV "${PROJECT_SOURCE_DIR}/model/GMS/opc.ua.gms.nodeset2.csv"
     FILE_BSD "${PROJECT_SOURCE_DIR}/model/GMS/opc.ua.gms.nodeset2.bsd"
-    NAMESPACE_MAP "9:http://opcfoundation.org/GMS/"
+    NAMESPACE_MAP "8:http://opcfoundation.org/GMS/"
     TARGET_PREFIX "${PROJECT_NAME}"
     OUTPUT_DIR "${SAMPLESERVER_GENERATED_NODESET_AND_DATATYPES_OUTPUT_DIR}"
     DEPENDS di ia machinery machinery_result machinetool
@@ -363,21 +363,26 @@ add_executable(
     MachineTools/MRMachineTool.cpp
     MachineTools/ShowcaseMachineTool.cpp
     MachineTools/SimulatedInstance.cpp
-    Robotics/BasicRobot.cpp
-    Robotics/InstantiatedRobot.cpp
+#    Robotics/BasicRobot.cpp
+#    Robotics/InstantiatedRobot.cpp
     SampleServer.cpp
     Woodworking/BasicWoodworking.cpp
     Woodworking/FullWoodworking.cpp
     Woodworking/InstantiatedWoodworking.cpp
 )
 
+#set_target_properties(${PROJECT_NAME} PROPERTIES LINKER_LANGUAGE CXX)
+#target_link_libraries(
+#    ${PROJECT_NAME} PUBLIC SampleServerLib Configuration ua_gen_machinetool ua_gen_robotics ua_gen_woodworking
+#                           ua_gen_gms
+#)
 set_target_properties(${PROJECT_NAME} PROPERTIES LINKER_LANGUAGE CXX)
 target_link_libraries(
     ${PROJECT_NAME}
     PUBLIC SampleServerLib
            Configuration
            ua_gen_machinetool
-           ua_gen_robotics
+#           ua_gen_robotics
            ua_gen_woodworking
            ua_gen_gms
            ua_gen_additivemanufacturing

--- a/SampleServer.cpp
+++ b/SampleServer.cpp
@@ -225,7 +225,7 @@ int main(int argc, char *argv[]) {
   namespace_machinery_generated(pServer);
   namespace_ia_generated(pServer);
   namespace_machinetool_generated(pServer);
-  UA_Server_addNamespace(pServer, "Need for namespace index");
+  /*UA_Server_addNamespace(pServer, "Need for namespace index");*/
   /*namespace_robotics_generated(pServer);*/
   namespace_woodworking_generated(pServer);
   namespace_machinery_result_generated(pServer);


### PR DESCRIPTION
Current Example Server has a Namespace "Need for namespace index". To make it look nice and not break, the namespace indices need to match in SampleServer.cpp and CMakeLists.txt.
This commit comments out all of the unused robotics spec so the fake namespace is not needed.

Reason for comments: robotics will probably added again in the future.