### PR TITLE
fix: Add missing #include <cstdint>

### DIFF
--- a/Configuration/Configuration.hpp
+++ b/Configuration/Configuration.hpp
@@ -2,10 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  *
- * Copyright 2021 (c) Christian von Arnim, ISW University of Stuttgart (for umati and VDW e.V.)
- * Copyright 2022 (c) Alen Galinec
+ * Copyright (c) 2021,2023 Christian von Arnim, ISW University of Stuttgart (for umati and VDW e.V.)
+ * Copyright (c) 2022 Alen Galinec
  */
 
+#include <cstdint>
 #include <optional>
 #include <string>
 #include <vector>

--- a/UmatiServerLib/BindHelper.hpp
+++ b/UmatiServerLib/BindHelper.hpp
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  *
- * Copyright 2020-2021 (c) Christian von Arnim, ISW University of Stuttgart (for umati and VDW e.V.)
+ * Copyright (c) 2020-2021,2023 Christian von Arnim, ISW University of Stuttgart (for umati and VDW e.V.)
  */
 
 #pragma once
@@ -11,6 +11,7 @@
 
 #include <Open62541Cpp/UA_BrowsePath.hpp>
 #include <Open62541Cpp/UA_NodeId.hpp>
+#include <cstdint>
 #include <iostream>
 #include <refl.hpp>
 

--- a/UmatiServerLib/StateMachine.hpp
+++ b/UmatiServerLib/StateMachine.hpp
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  *
- * Copyright 2020-2021 (c) Christian von Arnim, ISW University of Stuttgart (for umati and VDW e.V.)
+ * Copyright (c) 2020-2021, 2023 Christian von Arnim, ISW University of Stuttgart (for umati and VDW e.V.)
  */
 
 #pragma once
@@ -10,6 +10,7 @@
 #include <open62541/server.h>
 
 #include <Open62541Cpp/UA_NodeId.hpp>
+#include <cstdint>
 #include <list>
 
 #include "../OpcUaTypes/LocalizedText.hpp"


### PR DESCRIPTION
Due to updated libraries, `<cstdint>` needs to be included explicitly.